### PR TITLE
[Subs 1926] Fix exception handling for report parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'uk.ac.ebi.ait'
-version = '0.1.1-SNAPSHOT'
+version = '0.1.2-SNAPSHOT'
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/java/uk/ac/ebi/ait/filecontentvalidatorservice/config/ReportFileConfig.java
+++ b/src/main/java/uk/ac/ebi/ait/filecontentvalidatorservice/config/ReportFileConfig.java
@@ -2,7 +2,6 @@ package uk.ac.ebi.ait.filecontentvalidatorservice.config;
 
 import lombok.Data;
 import org.springframework.stereotype.Component;
-import uk.ac.ebi.ait.filecontentvalidatorservice.utils.FileUtil;
 
 import java.io.File;
 
@@ -12,7 +11,7 @@ public class ReportFileConfig {
     public static final String VALIDATE_DIR = "validate";
     public static final String PROCESS_DIR = "process";
 
-    private File outputDir = FileUtil.createTempDir();
+    private File outputDir;
     private File inputDir = new File( "." );
     private String contextType = "reads";
 }

--- a/src/main/java/uk/ac/ebi/ait/filecontentvalidatorservice/exception/FileHandleException.java
+++ b/src/main/java/uk/ac/ebi/ait/filecontentvalidatorservice/exception/FileHandleException.java
@@ -5,4 +5,8 @@ public class FileHandleException extends RuntimeException {
     public FileHandleException(String message) {
         super(message);
     }
+
+    public FileHandleException(String message, Exception originalCause) {
+        super(message, originalCause);
+    }
 }

--- a/src/main/java/uk/ac/ebi/ait/filecontentvalidatorservice/service/ErrorMessages.java
+++ b/src/main/java/uk/ac/ebi/ait/filecontentvalidatorservice/service/ErrorMessages.java
@@ -4,6 +4,6 @@ public class ErrorMessages {
 
     public static final String FILE_NOT_FOUND_BY_TARGET_PATH = "File not found with target path: %s";
     public static final String FILE_TYPE_NOT_SUPPORTED = "File type is not supported: %s";
-    public static final String VALIDATION_REPORT_FILE_ERROR = "Could not process the validation report file for file with id: %s";
+    public static final String VALIDATION_REPORT_FILE_ERROR = "Could not process the validation report file for file with id: %s. The original cause was: %s";
     public static final String SUBMISSION_FILE_COULD_NOT_BE_FOUND = "Could not find submission file for data file with ID: %s";
 }

--- a/src/main/java/uk/ac/ebi/ait/filecontentvalidatorservice/service/FileContentValidationHandler.java
+++ b/src/main/java/uk/ac/ebi/ait/filecontentvalidatorservice/service/FileContentValidationHandler.java
@@ -17,6 +17,7 @@ import uk.ac.ebi.ait.filecontentvalidatorservice.dto.ValidationAuthor;
 import uk.ac.ebi.ait.filecontentvalidatorservice.exception.FileContentValidationException;
 import uk.ac.ebi.ait.filecontentvalidatorservice.exception.FileHandleException;
 import uk.ac.ebi.ait.filecontentvalidatorservice.utils.FileContentValidatorMessages;
+import uk.ac.ebi.ait.filecontentvalidatorservice.utils.FileUtil;
 import uk.ac.ebi.ena.readtools.validator.ReadsValidator;
 import uk.ac.ebi.ena.webin.cli.validator.api.ValidationResponse;
 import uk.ac.ebi.ena.webin.cli.validator.file.SubmissionFile;
@@ -93,6 +94,9 @@ public class FileContentValidationHandler {
     public ValidationResponse handleFileContentValidation() {
         manifest = getReadsManifest();
         String submissionUUID = commandLineParameters.getSubmissionUUID();
+        String fileUUID = commandLineParameters.getFilesData().stream().map(FileParameters::getFileUUID).collect(Collectors.joining("_"));
+
+        reportFileConfig.setOutputDir(FileUtil.createTempDir(submissionUUID, fileUUID));
 
         this.validationDir = createSubmissionDir(ReportFileConfig.VALIDATE_DIR, submissionUUID);
         this.processDir = createSubmissionDir(ReportFileConfig.PROCESS_DIR, submissionUUID);
@@ -230,8 +234,9 @@ public class FileContentValidationHandler {
             throw new FileContentValidationException(
                     FileContentValidatorMessages.EXECUTOR_INIT_ERROR.format("Missing submission's UUID."));
         }
+
         File newDir =
-                createOutputDir(reportFileConfig.getOutputDir(), reportFileConfig.getContextType(), submissionUUID, dir);
+                createOutputDir(reportFileConfig.getOutputDir(), reportFileConfig.getContextType(), dir);
         if (!emptyDirectory(newDir)) {
             throw new FileContentValidationException(
                     FileContentValidatorMessages.EXECUTOR_EMPTY_DIRECTORY_ERROR.format(newDir));

--- a/src/main/java/uk/ac/ebi/ait/filecontentvalidatorservice/service/FileContentValidationHandler.java
+++ b/src/main/java/uk/ac/ebi/ait/filecontentvalidatorservice/service/FileContentValidationHandler.java
@@ -41,7 +41,6 @@ import java.util.stream.Collectors;
 import static uk.ac.ebi.ait.filecontentvalidatorservice.service.ErrorMessages.SUBMISSION_FILE_COULD_NOT_BE_FOUND;
 import static uk.ac.ebi.ait.filecontentvalidatorservice.service.ErrorMessages.VALIDATION_REPORT_FILE_ERROR;
 import static uk.ac.ebi.ait.filecontentvalidatorservice.utils.FileUtil.createOutputDir;
-import static uk.ac.ebi.ait.filecontentvalidatorservice.utils.FileUtil.emptyDirectory;
 
 @Service
 @Slf4j
@@ -235,13 +234,7 @@ public class FileContentValidationHandler {
                     FileContentValidatorMessages.EXECUTOR_INIT_ERROR.format("Missing submission's UUID."));
         }
 
-        File newDir =
-                createOutputDir(reportFileConfig.getOutputDir(), reportFileConfig.getContextType(), dir);
-        if (!emptyDirectory(newDir)) {
-            throw new FileContentValidationException(
-                    FileContentValidatorMessages.EXECUTOR_EMPTY_DIRECTORY_ERROR.format(newDir));
-        }
-        return newDir;
+        return createOutputDir(reportFileConfig.getOutputDir(), reportFileConfig.getContextType(), dir);
     }
 
     private File getSubmissionReportFile() {

--- a/src/main/java/uk/ac/ebi/ait/filecontentvalidatorservice/service/FileContentValidationHandler.java
+++ b/src/main/java/uk/ac/ebi/ait/filecontentvalidatorservice/service/FileContentValidationHandler.java
@@ -184,7 +184,7 @@ public class FileContentValidationHandler {
                 }
             }
         } catch (IOException ex) {
-            throw new FileHandleException(String.format(VALIDATION_REPORT_FILE_ERROR, fileUUID));
+            throw new FileHandleException(String.format(VALIDATION_REPORT_FILE_ERROR, fileUUID, ex.getMessage()), ex);
         }
 
         return validationResults;

--- a/src/main/java/uk/ac/ebi/ait/filecontentvalidatorservice/utils/FileUtil.java
+++ b/src/main/java/uk/ac/ebi/ait/filecontentvalidatorservice/utils/FileUtil.java
@@ -74,8 +74,8 @@ public class FileUtil {
 				.replaceAll("(?<=[^_])_+$", "");
 	}
 
-	public static File createTempDir() {
-			File folder = new File("temp/" + UUID.randomUUID().toString());
+	public static File createTempDir(String submissionUUID, String fileUUID) {
+			File folder = new File(String.join("/", "temp", submissionUUID, fileUUID, UUID.randomUUID().toString()));
 
 			assert(folder.mkdirs());
 

--- a/src/main/java/uk/ac/ebi/ait/filecontentvalidatorservice/utils/FileUtil.java
+++ b/src/main/java/uk/ac/ebi/ait/filecontentvalidatorservice/utils/FileUtil.java
@@ -18,24 +18,6 @@ public class FileUtil {
 		return new File(dir, Paths.get(filename).getFileName().toString() + suffix);
 	}
 
-	public static boolean emptyDirectory( File dir )
-	{
-		if (dir == null)
-			return false;
-	    if( dir.exists() )
-	    {
-	        File[] files = dir.listFiles();
-			for (File file : files) {
-				if (file.isDirectory()) {
-					emptyDirectory(file);
-				} else {
-					file.delete();
-				}
-			}
-	    }
-	    return dir.listFiles().length == 0;
-	}
-
 	public static File createOutputDir(File outputDir, String... dirs) {
 		if (outputDir == null) {
 			throw new FileHandleException(FileContentValidatorMessages.CLI_MISSING_OUTPUT_DIR_ERROR.text());

--- a/src/test/java/uk/ac/ebi/ait/filecontentvalidatorservice/service/FileContentValidationHandlerTest.java
+++ b/src/test/java/uk/ac/ebi/ait/filecontentvalidatorservice/service/FileContentValidationHandlerTest.java
@@ -60,7 +60,7 @@ public class FileContentValidationHandlerTest {
 
     @After
     public void tearDown() throws IOException {
-        deleteReportFileFolderAfterTestExecution(validationHandler.getOutputDir());
+        deleteReportFileFolderAfterTestExecution();
     }
 
     @Test
@@ -153,5 +153,20 @@ public class FileContentValidationHandlerTest {
                 validationHandler.createValidationResultByFileUUID(validationResponse, FILE_UUID);
 
         assertThat(validationResult.get(0).getValidationStatus(), is(equalTo(SingleValidationResultStatus.Pass)));
+    }
+
+    @Test
+    public void whenValidationExecuted2Times_Then2SeparateReportFoldersCreated() {
+        final String testFilePath = "reads/valid.bam";
+        String filesParam = TEST_INITIAL_FILE_PARAMS + "filePath=" + testFilePath;
+        final CommandLineParameters commandLineParameters = CommandLineParametersBuilder.build(filesParam,
+                ReadsManifest.FileType.BAM.toString(), submissionUUID);
+        validationHandler.setCommandLineParameters(commandLineParameters);
+        doReturn(getResourceFile(testFilePath)).when(this.validationHandler).getData(anyString());
+
+        validationHandler.handleFileContentValidation();
+        validationHandler.handleFileContentValidation();
+
+        assertThat(validationHandler.getOutputDir().getParentFile().list().length, is(equalTo(2)));
     }
 }

--- a/src/test/java/uk/ac/ebi/ait/filecontentvalidatorservice/service/ValidationHelper.java
+++ b/src/test/java/uk/ac/ebi/ait/filecontentvalidatorservice/service/ValidationHelper.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.Objects;
 
@@ -16,8 +17,8 @@ public class ValidationHelper {
         );
     }
 
-    public static  void deleteReportFileFolderAfterTestExecution(File outputDir) throws IOException {
-        Path folderToRemove = outputDir.getParentFile().toPath();
+    public static  void deleteReportFileFolderAfterTestExecution() throws IOException {
+        Path folderToRemove = Paths.get("temp");
 
         Files.walk(folderToRemove)
                 .sorted(Comparator.reverseOrder())

--- a/src/test/java/uk/ac/ebi/ait/filecontentvalidatorservice/service/reads/ReadsValidationTest.java
+++ b/src/test/java/uk/ac/ebi/ait/filecontentvalidatorservice/service/reads/ReadsValidationTest.java
@@ -61,7 +61,7 @@ public class ReadsValidationTest {
 
     @After
     public void tearDown() throws IOException {
-        deleteReportFileFolderAfterTestExecution(validationHandler.getOutputDir());
+        deleteReportFileFolderAfterTestExecution();
     }
 
     @Test


### PR DESCRIPTION
Changes:
- Add the root exception to the newly created one as the root cause
- Remove unneeded code that empties the folder of the report file
- Refactor report folder creation to /temp/submissionID/fileUUID/randomUUID
